### PR TITLE
fix: remove editor text persistence (#311)

### DIFF
--- a/src/components/TinyMCEEditor.jsx
+++ b/src/components/TinyMCEEditor.jsx
@@ -86,7 +86,7 @@ export default function TinyMCEEditor(props) {
         browser_spellcheck: true,
         a11y_advanced_options: true,
         autosave_interval: '1s',
-        autosave_restore_when_empty: true,
+        autosave_restore_when_empty: false,
         plugins: 'autosave codesample link lists image imagetools code emoticons charmap',
         toolbar: 'formatselect | bold italic underline'
           + ' | link blockquote openedx_code image'

--- a/src/discussions/comments/comment/CommentEditor.jsx
+++ b/src/discussions/comments/comment/CommentEditor.jsx
@@ -49,7 +49,12 @@ function CommentEditor({
     editReasonCode: comment?.lastEdit?.reasonCode || '',
   };
 
-  const saveUpdatedComment = async (values) => {
+  const handleCloseEditor = (resetForm) => {
+    resetForm({ values: initialValues });
+    onCloseEditor();
+  };
+
+  const saveUpdatedComment = async (values, { resetForm }) => {
     if (comment.id) {
       const payload = {
         ...values,
@@ -63,7 +68,7 @@ function CommentEditor({
     if (editorRef.current) {
       editorRef.current.plugins.autosave.removeDraft();
     }
-    onCloseEditor();
+    handleCloseEditor(resetForm);
   };
   // The editorId is used to autosave contents to localstorage. This format means that the autosave is scoped to
   // the current comment id, or the current comment parent or the curren thread.
@@ -82,6 +87,7 @@ function CommentEditor({
         handleSubmit,
         handleBlur,
         handleChange,
+        resetForm,
       }) => (
         <Form onSubmit={handleSubmit}>
           {canDisplayEditReason && (
@@ -137,7 +143,7 @@ function CommentEditor({
           <div className="d-flex py-2 justify-content-end">
             <Button
               variant="outline-primary"
-              onClick={onCloseEditor}
+              onClick={() => handleCloseEditor(resetForm)}
             >
               {intl.formatMessage(messages.cancel)}
             </Button>

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -113,7 +113,21 @@ function PostEditor({
     }
     return settings.alwaysDivideInlineDiscussions || settings.dividedInlineDiscussions.includes(tId);
   };
-  const hideEditor = () => {
+
+  const initialValues = {
+    postType: post?.type || 'discussion',
+    topic: post?.topicId || topicId || nonCoursewareTopics?.[0]?.id,
+    title: post?.title || '',
+    comment: post?.rawBody || '',
+    follow: isEmpty(post?.following) ? true : post?.following,
+    anonymous: allowAnonymous ? false : undefined,
+    anonymousToPeers: allowAnonymousToPeers ? false : undefined,
+    editReasonCode: post?.lastEdit?.reasonCode || '',
+    cohort: post?.cohort || 'default',
+  };
+
+  const hideEditor = (resetForm) => {
+    resetForm({ values: initialValues });
     if (editExisting) {
       const newLocation = discussionsPath(commentsPagePath, {
         courseId,
@@ -126,8 +140,7 @@ function PostEditor({
   };
   // null stands for no cohort restriction ("All learners" option)
   const selectedCohort = (cohort) => (cohort === 'default' ? null : cohort);
-
-  const submitForm = async (values) => {
+  const submitForm = async (values, { resetForm }) => {
     if (editExisting) {
       await dispatchSubmit(updateExistingThread(postId, {
         topicId: values.topic,
@@ -155,7 +168,7 @@ function PostEditor({
     if (editorRef.current) {
       editorRef.current.plugins.autosave.removeDraft();
     }
-    hideEditor();
+    hideEditor(resetForm);
   };
 
   useEffect(() => {
@@ -174,18 +187,6 @@ function PostEditor({
       </div>
     );
   }
-
-  const initialValues = {
-    postType: post?.type || 'discussion',
-    topic: post?.topicId || topicId || nonCoursewareTopics?.[0]?.id,
-    title: post?.title || '',
-    comment: post?.rawBody || '',
-    follow: isEmpty(post?.following) ? true : post?.following,
-    anonymous: allowAnonymous ? false : undefined,
-    anonymousToPeers: allowAnonymousToPeers ? false : undefined,
-    editReasonCode: post?.lastEdit?.reasonCode || '',
-    cohort: post?.cohort || 'default',
-  };
 
   const validationSchema = Yup.object().shape({
     postType: Yup.mixed()
@@ -226,6 +227,7 @@ function PostEditor({
         handleSubmit,
         handleBlur,
         handleChange,
+        resetForm,
       }) => (
         <Form className="m-4 card p-4" onSubmit={handleSubmit}>
           <h3>
@@ -400,7 +402,7 @@ function PostEditor({
           <div className="d-flex justify-content-end">
             <Button
               variant="outline-primary"
-              onClick={hideEditor}
+              onClick={() => hideEditor(resetForm)}
             >
               {intl.formatMessage(messages.cancel)}
             </Button>


### PR DESCRIPTION
## Description

Backsports the changes of https://github.com/openedx/frontend-app-discussions/pull/311 so that
the editor isn't prefilled with the data from a previously saved post.

## Testing instructions

- This change has been deployed to https://es1.kgdocluster.opencraft.hosting
- On the discussion forum for any course, create some posts
- Go to `All Posts` and click the `Add Post` button, verify that the inputs are not prepopulated with earlier posts. Example of the issue in the GIF

![discussion forum](https://user-images.githubusercontent.com/1470652/228225261-176e1c44-0da3-4797-afef-31507fd90f40.gif)
